### PR TITLE
Make the number of collectors shown when calling /collectors API endpoint configurable via an attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,3 +23,6 @@
 # Set to true to disable the collector on this node
 default['sumologic']['disabled'] = false
 default['sumologic']['log_sources']['default_category'] = 'log'
+
+# limit the amount of collectors shown when querying the sumologic /collector API endpoint
+default['sumologic']['api_collectors_limit'] = 15000

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -4,23 +4,25 @@ require 'json'
 class Sumologic
   class ApiError < RuntimeError; end
 
-  def self.collector_exists?(node_name, email, pass)
+  def self.collector_exists?(node_name, email, pass, api_collectors_limit)
     collector = Sumologic::Collector.new(
       :name => node_name,
       :api_username => email,
-      :api_password => pass
+      :api_password => pass,
+      :api_collectors_limit => api_collectors_limit
     )
     collector.exist?
   end
 
   class Collector
-    attr_reader :name, :api_username, :api_password
+    attr_reader :name, :api_username, :api_password, :api_collectors_limit
 
     def initialize(opts = {})
       @name = opts[:name]
       @api_username = opts[:api_username]
       @api_password = opts[:api_password]
       @api_endpoint = opts[:api_endpoint] || 'https://api.sumologic.com/api/v1'
+      @api_collectors_limit = opts[:api_collectors_limit]
     end
 
     def api_endpoint
@@ -67,7 +69,7 @@ class Sumologic
     end
 
     def list_collectors
-      uri = URI.parse(api_endpoint + '/collectors?limit=10000')
+      uri = URI.parse(api_endpoint + '/collectors?limit=' + api_collectors_limit.to_s)
       request = Net::HTTP::Get.new(uri.request_uri)
       api_request(:uri => uri, :request => request)
     end

--- a/libraries/sumo_source_provider.rb
+++ b/libraries/sumo_source_provider.rb
@@ -19,7 +19,8 @@ class Chef
           :name => node.name,
           :api_username => node['sumologic']['userID'],
           :api_password => node['sumologic']['password'],
-          :api_endpoint => node['sumologic']['api_endpoint']
+          :api_endpoint => node['sumologic']['api_endpoint'],
+          :api_collectors_limit => node['sumologic']['api_collectors_limit']
         )
 
         @current_resource = Chef::Resource::SumoSource.new(@new_resource.name)


### PR DESCRIPTION
Default value to 15000, we can overwrite this value when required by simply overriding the attribute.